### PR TITLE
Parse metadata & extract the layout

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,24 +5,27 @@ version = "0.1.0"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
-LazyStack = "1fad7336-0346-5a1a-a56f-a06ba010965b"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 OMETIFF = "2d0ec36b-e807-5756-994b-45af29551fcf"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
+AxisArrays = "0.4"
+BlockArrays = "0.16"
 ColorTypes = "0.11"
+EzXML = "1"
 FileIO = "1"
 FixedPointNumbers = "0.8"
 ImageMetadata = "0.9"
-LazyStack = "0.0"
 OMETIFF = "0.4"
+Unitful = "1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,17 @@ authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
+AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
 LazyStack = "1fad7336-0346-5a1a-a56f-a06ba010965b"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 OMETIFF = "2d0ec36b-e807-5756-994b-45af29551fcf"
-TiffImages = "731e570b-9d59-4bfa-96dc-6df516fadf69"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 ColorTypes = "0.11"
@@ -20,7 +23,6 @@ FixedPointNumbers = "0.8"
 ImageMetadata = "0.9"
 LazyStack = "0.0"
 OMETIFF = "0.4"
-TiffImages = "0.5"
 julia = "1.6"
 
 [extras]

--- a/src/ZeissMicroscopyFormat.jl
+++ b/src/ZeissMicroscopyFormat.jl
@@ -5,12 +5,12 @@ using Dates
 
 using FileIO
 using OMETIFF
-using EzXML
+using EzXML: EzXML, eachelement, firstelement, nextelement, nodename, nodecontent
 using FixedPointNumbers
 using ColorTypes
 using ImageMetadata
 using Unitful
-using LazyStack
+using BlockArrays
 
 # Documentation on this format is proprietary but available by request for free:
 #    https://www.zeiss.com/microscopy/int/products/microscope-software/zen/czi.html
@@ -73,13 +73,7 @@ struct DirectoryEntryDVFixed
     spare4::UInt32
     dimensioncount::Int32
 end
-
-struct DirectoryEntryDV
-    fixed::DirectoryEntryDVFixed
-    dimensionentries::Vector{DimensionEntryDV}
-end
-
-function DirectoryEntryDV(s::Stream)
+function DirectoryEntryDVFixed(s::Stream)
     c1, c2 = read(s, UInt8), read(s, UInt8)
     @assert Char(c1) == 'D' && Char(c2) == 'V'
     # fixed = reinterpret(DirectoryEntryDVFixed, read(s, sizeof(DirectoryEntryDVFixed)))[]
@@ -92,7 +86,21 @@ function DirectoryEntryDV(s::Stream)
                                   read(s, UInt32),   # spare4
                                   read(s, Int32),
     )
-    @assert iszero(fixed.compression)   # FIXME: support compression
+    # The following constraint comes from the fact that the size of the `Fill` section
+    # of SubBlockSegments is `max(256-n, 0)` where `n = dimensioncount*20 + 28 + 16`
+    # and here we've hard-coded it to be the first of these.
+    @assert fixed.dimensioncount <= 10 "FIXME: more than 10 dimensions unsupported"
+    return fixed
+end
+
+struct DirectoryEntryDV
+    fixed::DirectoryEntryDVFixed
+    dimensionentries::Vector{DimensionEntryDV}
+end
+function DirectoryEntryDV(s::Stream)
+    fixed = DirectoryEntryDVFixed(s)
+    @assert iszero(fixed.compression) "FIXME: support compression"
+    @assert iszero(fixed.pyramidtype) "FIXME: support pyramids"
     # entries = reinterpret(DimensionEntryDV, read(s, fixed.dimensioncount * sizeof(DimensionEntryDV)))
     entries = [DimensionEntryDV(s) for _ = 1:fixed.dimensioncount]
     return DirectoryEntryDV(fixed, entries)
@@ -114,19 +122,33 @@ struct SubBlockSegmentSizes
     attachsize::Int32
     datasize::Int64
 end
-struct DataSegment{C<:Colorant,N}
-    offset::Int64
-    dims::NTuple{N,Int}
-    dimnames::NTuple{N,Char}
-    metadata
-end
+SubBlockSegmentSizes(s::Stream) = SubBlockSegmentSizes(read(s, Int32), read(s, Int32), read(s, Int64))
 
-function read_subblock(s::Stream, d::DirectoryEntryDV) where C<:Colorant
+struct SubBlock{C<:Colorant,N}
+    sbss::SubBlockSegmentSizes
+    d::DirectoryEntryDV
+    metadataoffset::Int64
+    dataoffset::Int64
+    dims::NTuple{N,Int}
+    dimnames::NTuple{N,Symbol}
+end
+function SubBlock{C,N}(s::Stream, pos::Integer, sbss::SubBlockSegmentSizes, d::DirectoryEntryDV) where {C<:Colorant,N}
+    mdpos = Int(pos) + 256
+    return SubBlock{C,N}(sbss, d, mdpos, mdpos + sbss.metasize, size(d)::NTuple{N,Int}, names(d)::NTuple{N,Symbol})
+end
+function SubBlock{C,N}(s::Stream, d::DirectoryEntryDV) where {C<:Colorant,N}
+    seek(s, d.fileposition)
+    sid = read(s, 16)
+    @assert sid == SUBBLOCK
+    read(s, 16)
+    sbss = SubBlockSegmentSizes(s)
+    return SubBlock{C,N}(s, d.fileposition + 32, sbss, d)
+end
+function SubBlock(s::Stream)
     pos = position(s)
-    sbss = reinterpret(SubBlockSegmentSizes, read(s, sizeof(SubBlockSegmentSizes)))[1]
-    seek(s, pos+256)
-    md = parsexml(String(read(s, sbss.metasize)))
-    return DataSegment{pixeltypes[d.pixeltype],Int(d.dimensioncount)}(position(s), )
+    sbss = SubBlockSegmentSizes(s)
+    d = DirectoryEntryDV(s)
+    return SubBlock{pixeltypes[d.pixeltype],Int(d.dimensioncount)}(s, pos, sbss, d)
 end
 
 function load(f::File{format"CZI"})
@@ -168,9 +190,9 @@ function load(s::Stream{format"CZI"}; keywords...)
     # if idx !== nothing
     #     rawxml = rawxml[1:prevind(rawxml, idx)]
     # end
-    omexml = OMETIFF.root(OMETIFF.parsexml(rawxml))
+    omexml = EzXML.root(EzXML.parsexml(rawxml))
 
-    # Subblocks
+    # Subblock directory
     seek(s, dirpos)
     sid = read(s, 16)
     @assert sid == RAWDIR
@@ -179,42 +201,46 @@ function load(s::Stream{format"CZI"}; keywords...)
     seek(s, dirpos + 128 + 32)
     entries = [DirectoryEntryDV(s) for i = 1:entry_count]
     pixeltype = first(entries).pixeltype
-    nd = first(entries).dimensioncount
+    T = pixeltypes[pixeltype]
+    nd = Int(first(entries).dimensioncount)
     sz = size(first(entries))
-    @show names(first(entries))
     # @show sz map(size, entries)
     @assert all(d -> d.pixeltype == pixeltype, entries) "All pixel types must be identical"
     @assert all(d -> d.dimensioncount == nd, entries) "The number of dimensions must be consistent"
     @assert all(d -> size(d)[1:end-1] == sz[1:end-1], entries) "Leading sizes must be identical"
+    # Subblocks (mostly to parse the XML)
+    subblocks = [SubBlock{T,nd}(s, entry) for entry in entries]
+
+    nb = sizeof(T)::Int
+    @assert all(subblock -> iszero(subblock.dataoffset % nb), subblocks) "FIXME: unaligned chunk boundaries are not yet supported"
 
     # Data
     # FIXME? To avoid another layer of `ReinterpretArray`, it's easiest to interpret the raw data
     # as having the eltype of the image. However, it's possible the chunk boundaries will not
-    # always be aligned commensurately. For now let's run with this, but it may require generalization.
-    T = pixeltypes[pixeltype]
-    nb = sizeof(T)::Int
-    @assert all(d -> iszero(d.fileposition % nb), entries) "FIXME: chunk boundaries are not aligned"
+    # always be aligned commensurately. For now, let's assume it's OK, but it may require generalization.
     C, axs, shear = layout(omexml, T)
     @show C axs shear
     seek(s, 0)
     mm = Mmap.mmap(s.io, Vector{T}, filesize(s.io) ÷ nb)
-    blocks = [makeview(mm, entry, nb) for entry in entries]
+    blocks = [makeview(mm, subblock, nb) for subblock in subblocks]
+    subblock = first(subblocks)
+    blocked = mortar(reshape(blocks, 1, 1, map(name -> length(axs[name]), subblock.dimnames[3:end])...))
 
-    return ImageMeta(stack(blocks); xml=omexml, entries)  # FIXME
+    return ImageMeta(blocked; xml=omexml, subblocks, shear, suppress=Set([:xml, :subblocks]))
 end
 
-function makeview(v, entry, nb)
-    start = entry.fileposition ÷ nb
-    sz = size(entry)
+function makeview(v, subblock::SubBlock, nb)
+    start = subblock.dataoffset ÷ nb
+    sz = size(subblock.d)
     nel = prod(sz)
-    # Drop the color channel ('C') if eltype(v) <: Gray
-    if eltype(v) <: AbstractGray
-        nms = names(entry)
-        idx = findfirst(==(:C), nms)
-        if idx !== nothing
-            sz = (sz[1:idx-1]..., sz[idx+1:end]...)
-        end
-    end
+    # # Drop the color channel ('C') if eltype(v) <: Gray
+    # if eltype(v) <: AbstractGray
+    #     nms = names(subblock.d)
+    #     idx = findfirst(==(:C), nms)
+    #     if idx !== nothing
+    #         sz = (sz[1:idx-1]..., sz[idx+1:end]...)
+    #     end
+    # end
     return reshape(view(v, start:start+nel-1), sz)
 end
 
@@ -269,6 +295,11 @@ function layout(omexml, ::Type{T}) where T
             end
         end
     end
+    pixelsizenode = only(findall("//ImagePixelSize", omexml))
+    yinc, xinc = parse.(Float64, split(nodecontent(pixelsizenode), ','))
+    axs[:C] = 1:length(wavelengths)
+    axs[:Y] = range(0 * u"μm", step=yinc * u"μm", length=szs[:Y])
+    axs[:X] = range(0 * u"μm", step=xinc * u"μm", length=szs[:X])
     return wavelengths, axs, shear
 end
 


### PR DESCRIPTION
This extracts the geometry of the image and sets up the required "raw array" layout. The main missing step remaining would be bespoke color types that encode the wavelengths and intensities in the color channels as a Colorant.

Still no tests because I'm unaware of any test files distributed by Zeiss for validation.